### PR TITLE
Add missing jigsaw information on profile page

### DIFF
--- a/apps/single-view/src/Interfaces/customerProfileInterfaces.tsx
+++ b/apps/single-view/src/Interfaces/customerProfileInterfaces.tsx
@@ -12,6 +12,12 @@ export interface customerProfile {
   preferredFirstName: string | null;
   preferredSurname: string | null;
   dateOfBirth: string;
+  pregnancyDueDate: string | null;
+  accommodationTypeId: string | null;
+  housingCircumstanceId: string | null;
+  isSettled: boolean | null;
+  supportWorker: string | null;
+  gender: string | null;
   dateofDeath: string | null;
   placeOfBirth: string;
   personTypes: string[] | null;

--- a/apps/single-view/src/Views/CustomerView/Profile.tsx
+++ b/apps/single-view/src/Views/CustomerView/Profile.tsx
@@ -153,11 +153,39 @@ export const Profile = (props: Props) => {
         <DescriptionListItem title="NHS number" testId="nhsNo">
           {person.nhsNumber}
         </DescriptionListItem>
-        <DescriptionListItem title="Date of Death" testId="dateOfDeath">
-          {person.dateofDeath}
+        <DescriptionListItem
+          title={"Pregnancy due Date"}
+          testId={"pregnancyDueDate"}
+        >
+          {person.pregnancyDueDate &&
+            formatDateOfBirth(person.pregnancyDueDate)}
+        </DescriptionListItem>
+        <DescriptionListItem
+          title={"Accommodation type Id"}
+          testId={"accommodationTypeId"}
+        >
+          {person.accommodationTypeId}
+        </DescriptionListItem>
+        <DescriptionListItem
+          title={"Housing circumstance Id"}
+          testId={"housingCircumstanceId"}
+        >
+          {person.housingCircumstanceId}
+        </DescriptionListItem>
+        <DescriptionListItem title={"Settled"} testId={"isSettled"}>
+          {person.isSettled ? "Y" : "N"}
+        </DescriptionListItem>
+        <DescriptionListItem title={"Support worker"} testId={"supportWorker"}>
+          {person.supportWorker}
+        </DescriptionListItem>
+        <DescriptionListItem title={"Gender"} testId={"gender"}>
+          {person.gender}
         </DescriptionListItem>
         <DescriptionListItem title="Is a Minor" testId="isMinor">
           {person.isAMinor ? "Y" : "N"}
+        </DescriptionListItem>
+        <DescriptionListItem title="Date of Death" testId="dateOfDeath">
+          {person.dateofDeath}
         </DescriptionListItem>
         <h3>System Ids</h3>
         {systemIds &&

--- a/cypress/fixtures/person-profile.json
+++ b/cypress/fixtures/person-profile.json
@@ -48,9 +48,15 @@
             "postcode": "SW19 1AA"
         }},
         "dateOfBirth": "1980-02-01T00:00:00Z",
-        "niNo": null,
+        "niNo": "SL203040",
         "dateOfDeath": null,
         "isAMinor": false,
+        "pregnancyDueDate": "2022-12-25T00:00:00",
+        "accommodationTypeId": 10,
+        "housingCircumstanceId": 11,
+        "isSettled": false,
+        "supportWorker": "James Brown",
+        "gender": "Female",
         "cautionaryAlerts": [
             {
                 "dateModified": "2020-02-01T00:00:00Z",

--- a/cypress/integration/4-profile.spec.ts
+++ b/cypress/integration/4-profile.spec.ts
@@ -75,6 +75,30 @@ describe('Profile', () => {
     it('displays is a minor', ()=>{
       cy.get('[data-testid="isMinor"]').should('have.text', "N", {timeout: 10000});
     });
+    
+    it('displays pregnancy due date', () => {
+      cy.get('[data-testid="pregnancyDueDate"]').should('have.text', "25/12/2022", {timeout: 10000})
+    });
+    
+    it('displays accommodation type id', () => {
+      cy.get('[data-testid="accommodationTypeId"]').should('have.text', '10', {timeout: 10000});
+    });
+    
+    it('displays housing circumstance id', () => {
+      cy.get('[data-testid="housingCircumstanceId"]').should('have.text', '11', {timeout: 10000});
+    });
+
+    it('displays is settled', () => {
+      cy.get('[data-testid="isSettled"]').should('have.text', 'N', {timeout: 10000});
+    });
+
+    it('displays support worker', () => {
+      cy.get('[data-testid="supportWorker"]').should('have.text', 'James Brown', {timeout: 10000});
+    });
+
+    it('displays gender', () => {
+      cy.get('[data-testid="gender"]').should('have.text', 'Female', {timeout: 10000});
+    });
 
     it('displays Council Tax Information', () => {
       cy.get('[data-testid="accountRef"]').should('have.text', "34596507", {timeout: 10000});


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/X96j0Fwt/239-display-missing-info-from-jigsaw

## Describe this PR
### What is the problem we're trying to solve
#### Include following missing info on customer profile page. 
- pregnancy Due Date
- accommodation Type 
- housing Circumstances
- is Settled
- support Worker - 
- gender

### What changes have we introduced

- Update customerProfile interface to include missing info. 
- Update profile page to display missing info. 

#### Checklist

- [x] Added tests to cover all new production code. 
- [x] Checked for potential refactor and made todo note to change in future. 

#### Screenshot 

![screencapture](https://user-images.githubusercontent.com/31739633/182130786-0ea64439-f728-4bae-9e9a-05a6d3f04064.png)

