### PR TITLE
Updated banner from alpha to pilot

### DIFF
--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -82,7 +82,7 @@ const App = (): JSX.Element => {
           </nav>
         </div>
       </div>
-      <PhaseBanner tag="alpha" variant="green">
+      <PhaseBanner tag="pilot" variant="green">
         <span>
           This is a new service - your{" "}
           <a href={feedbackLink} target="_blank">


### PR DESCRIPTION
The banner now shows alpha instead of pilot at the top
![image](https://user-images.githubusercontent.com/74552077/182398621-260d0b0e-ec94-4653-a61b-0e5cc1e8ace6.png)
