### PR TITLE
Display message on homelessness cases tab for non-jigsaw users

### DIFF
--- a/apps/single-view/src/Views/CustomerView/Cases.tsx
+++ b/apps/single-view/src/Views/CustomerView/Cases.tsx
@@ -56,7 +56,7 @@ export const Cases = (props: Props): JSX.Element => {
       <CaseSummary jigsawCaseResponse={cases} />
     ) : (
       <div className="govuk-inset-text lbh-inset-text" data-testid="notFound">
-        There were no active cases found.
+        There were no active homelessness cases found for this customer.
       </div>
     );
   }

--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -23,6 +23,7 @@ export const CustomerView = () => {
   const [dataSourceError, setDataSourceError] =
     useState<Array<SystemId> | null>();
   const [systemIds, setSystemIds] = useState<Array<SystemId>>();
+  const nullOrEmpty = (item: string): boolean => item == null || item == "";
 
   const loadPerson = async (): Promise<customerResponse | null> => {
     try {
@@ -139,7 +140,16 @@ export const CustomerView = () => {
           />
         </section>
         <section className="govuk-tabs__panel" id="cases">
-          <Cases customerId={jigsawId} />
+          {nullOrEmpty(jigsawId) ? (
+            <p
+              className="govuk-inset-text lbh-inset-text"
+              data-testid="homelessnessCasesNotFound"
+            >
+              There were no active homelessness cases found for this customer.
+            </p>
+          ) : (
+            <Cases customerId={jigsawId} />
+          )}
         </section>
       </div>
     </>


### PR DESCRIPTION
## Link to Trello card
[Non-jigsaw records load cases tab indefinitely](https://trello.com/c/QCNicmtB/246-non-jigsaw-records-load-cases-tab-indefinitely)

## Describe this PR

### What is the problem we're trying to solve
Currently a loading spinner appears indefinitely on the Active Homelessness Case tab for the customers without jigsaw record, giving user the impression that the existing data is not loading. 

### What changes have we introduced
- A condition is set to check if jigsaw id exists otherwise display the message. 

### Screenshot
![image](https://user-images.githubusercontent.com/31739633/183037590-cce7d466-e49b-4b3b-bd51-e8df30854167.png)