### PR TITLE
fix string const to match dataSource

### DIFF
--- a/apps/single-view/src/Interfaces/dataSources.tsx
+++ b/apps/single-view/src/Interfaces/dataSources.tsx
@@ -1,5 +1,5 @@
 export const Jigsaw = "Jigsaw";
 export const Housing = "PersonAPI";
 export const AcademyCT = "Academy-CouncilTax";
-export const Benefits = "Academy-Benefits";
+export const Benefits = "Academy-benefits";
 export const SingleView = "single-view";

--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -13,7 +13,6 @@ import {
 import { NotFound } from "../../Components";
 import { SystemId } from "../../Interfaces/systemIdInterface";
 import { Cases } from "./Cases";
-import id from "date-fns/esm/locale/id/index.js";
 
 export const CustomerView = () => {
   const { dataSource, id } = useParams<UrlParams>();


### PR DESCRIPTION
https://trello.com/c/7dw5K70b/272-claimant-details-are-not-loading
https://trello.com/c/1UrLxSCn/262-academy-cases-failing-to-load


Fix string const to match data returning from API (easier than rerunning dataSource migrations)

Remove unused import 