### PR TITLE
Prompt to sign in to Jigsaw when needed and display sign in when not signed in

### DIFF
--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -10,6 +10,8 @@ const {
   welcome,
   signIn,
   signOut,
+  loginJigsaw,
+  jigsawLoginLink,
   branding: { hackney, manageMyHome },
 } = locale;
 
@@ -71,6 +73,11 @@ const App = (): JSX.Element => {
                   <p>
                     {welcome} <b>{auth.name}</b>
                   </p>
+                  {(document.cookie.indexOf("jigsawToken") == -1) &&
+                  <Link as="button" className="lbh-signout">
+                    <a href={jigsawLoginLink}>{loginJigsaw}</a>
+                  </Link>
+                  }
                   <Link as="button" onClick={() => logout()} className="lbh-signout">
                     {signOut}
                   </Link>

--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -74,9 +74,9 @@ const App = (): JSX.Element => {
                     {welcome} <b>{auth.name}</b>
                   </p>
                   {(document.cookie.indexOf("jigsawToken") == -1) &&
-                  <Link as="button" className="lbh-signout">
-                    <a href={jigsawLoginLink + "?redirect=" + window.location.pathname} data-testid="jigsawloginHeader">{loginJigsaw}</a>
-                  </Link>
+                  <RouterLink to={jigsawLoginLink + "?redirect=" + window.location.pathname} data-testid="jigsawloginHeader">
+                    {loginJigsaw}
+                  </RouterLink>
                   }
                   <Link as="button" onClick={() => logout()} className="lbh-signout">
                     {signOut}

--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -75,7 +75,7 @@ const App = (): JSX.Element => {
                   </p>
                   {(document.cookie.indexOf("jigsawToken") == -1) &&
                   <Link as="button" className="lbh-signout">
-                    <a href={jigsawLoginLink + "?redirect=" + window.location.pathname}>{loginJigsaw}</a>
+                    <a href={jigsawLoginLink + "?redirect=" + window.location.pathname} data-testid="jigsawloginHeader">{loginJigsaw}</a>
                   </Link>
                   }
                   <Link as="button" onClick={() => logout()} className="lbh-signout">

--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -75,7 +75,7 @@ const App = (): JSX.Element => {
                   </p>
                   {(document.cookie.indexOf("jigsawToken") == -1) &&
                   <Link as="button" className="lbh-signout">
-                    <a href={jigsawLoginLink}>{loginJigsaw}</a>
+                    <a href={jigsawLoginLink + "?redirect=" + window.location.pathname}>{loginJigsaw}</a>
                   </Link>
                   }
                   <Link as="button" onClick={() => logout()} className="lbh-signout">

--- a/apps/header/src/services/locale.ts
+++ b/apps/header/src/services/locale.ts
@@ -2,6 +2,8 @@ const locale = {
   welcome: "Welcome",
   signOut: "Sign out",
   signIn: "Sign in",
+  loginJigsaw: "Log in to Jigsaw",
+  jigsawLoginLink: "/jigsawLogin",
   branding: {
     hackney: "Hackney",
     manageMyHome: "Single View 2.0",

--- a/apps/single-view/src/Components/JigsawLogin.tsx
+++ b/apps/single-view/src/Components/JigsawLogin.tsx
@@ -31,7 +31,12 @@ export const JigsawLogin = () => {
           let date = new Date();
           date.setTime(date.getTime() + 10 * 60 * 60 * 1000);
           document.cookie = `jigsawToken=${token}; expires=${date.toUTCString()}`;
-          document.location = "/";
+          document.cookie = `jigsawDismissed=false; expires=${date.toUTCString()}`;
+
+          const params = new URLSearchParams(window.location.search)
+          const redirectUrl = params.get("redirect");
+            document.location = redirectUrl !== null ? redirectUrl : '/';
+
         })
         .catch((reason) => {
           console.error(reason.message);
@@ -64,7 +69,7 @@ export const JigsawLogin = () => {
               </h2>
             </div>
             <div className="govuk-notification-banner__content">
-              Please use your Jigsaw user name & password to login, granting you
+              Please use your Jigsaw username & password to login, granting you
               access to the data presented at Single view from Jigsaw.
               <br />
               <a

--- a/apps/single-view/src/Components/JigsawLogin.tsx
+++ b/apps/single-view/src/Components/JigsawLogin.tsx
@@ -33,10 +33,9 @@ export const JigsawLogin = () => {
           document.cookie = `jigsawToken=${token}; expires=${date.toUTCString()}`;
           document.cookie = `jigsawDismissed=false; expires=${date.toUTCString()}`;
 
-          const params = new URLSearchParams(window.location.search)
+          const params = new URLSearchParams(window.location.search);
           const redirectUrl = params.get("redirect");
-            document.location = redirectUrl !== null ? redirectUrl : '/';
-
+          document.location = redirectUrl !== null ? redirectUrl : "/";
         })
         .catch((reason) => {
           console.error(reason.message);

--- a/apps/single-view/src/Views/CustomerView/Cases.tsx
+++ b/apps/single-view/src/Views/CustomerView/Cases.tsx
@@ -33,17 +33,21 @@ export const Cases = (props: Props): JSX.Element => {
     }
   }, [props.customerId]);
 
+  var currentPathName = window.location.pathname;
+  var jigsawTokenMessage = [<p>You are signed in to Jigsaw - this is probably a system issue</p>]
+  if (document.cookie.indexOf("jigsawToken") == -1) { // if jigsawToken NOT set
+    jigsawTokenMessage = [
+      <p>If you have access to Jigsaw please <a href={`/jigsawLogin?redirect=${currentPathName}`}>Log in to Jigsaw</a></p>,
+    ]
+  }
+
   if (getCasesError) {
     return (
       <ErrorSummary
         id="singleViewNotesError"
         title="Error"
-        description="Unable to load cases. If you have access to Jigsaw please log in."
-        children={
-          <a href="/jigsawLogin" target="_blank">
-            Log in to Jigsaw
-          </a>
-        }
+        description="Unable to load cases."
+        children={jigsawTokenMessage}
       />
     );
   }

--- a/apps/single-view/src/Views/CustomerView/Cases.tsx
+++ b/apps/single-view/src/Views/CustomerView/Cases.tsx
@@ -34,11 +34,24 @@ export const Cases = (props: Props): JSX.Element => {
   }, [props.customerId]);
 
   var currentPathName = window.location.pathname;
-  var jigsawTokenMessage = [<p>You are signed in to Jigsaw - this is probably a system issue</p>]
-  if (document.cookie.indexOf("jigsawToken") == -1) { // if jigsawToken NOT set
-    jigsawTokenMessage = [
-      <p>If you have access to Jigsaw please <a href={`/jigsawLogin?redirect=${currentPathName}`}>Log in to Jigsaw</a></p>,
-    ]
+  if (document.cookie.indexOf("jigsawToken") == -1) {
+    // if jigsawToken is NOT set
+    var jigsawTokenMessage = [
+      <p>
+        If you have access to Jigsaw please{" "}
+        <a
+          href={`/jigsawLogin?redirect=${currentPathName}`}
+          data-testid="jigsawLoginErrorSummary"
+        >
+          Log in to Jigsaw
+        </a>
+      </p>,
+    ];
+  } else {
+    // jigsawToken set but still failed
+    var jigsawTokenMessage = [
+      <p>You are signed in to Jigsaw - this is probably a system issue</p>,
+    ];
   }
 
   if (getCasesError) {

--- a/apps/single-view/src/Views/CustomerView/Cases.tsx
+++ b/apps/single-view/src/Views/CustomerView/Cases.tsx
@@ -38,7 +38,12 @@ export const Cases = (props: Props): JSX.Element => {
       <ErrorSummary
         id="singleViewNotesError"
         title="Error"
-        description="Unable to load cases. If you have access to Jigsaw please log in with the link above."
+        description="Unable to load cases. If you have access to Jigsaw please log in."
+        children={
+          <a href="/jigsawLogin" target="_blank">
+            Log in to Jigsaw
+          </a>
+        }
       />
     );
   }

--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -55,11 +55,7 @@ export const CustomerView = () => {
   const systemIdError = (dataSource: any) => {
     const ifJigsaw =
       dataSource.systemName == Jigsaw && dataSource.error == "Unauthorised";
-    const jigsawLink = (
-      <span>
-        If you have access to Jigsaw, please login.
-      </span>
-    );
+    const jigsawLink = <span>If you have access to Jigsaw, please login.</span>;
 
     return (
       <div

--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -57,14 +57,7 @@ export const CustomerView = () => {
       dataSource.systemName == Jigsaw && dataSource.error == "Unauthorised";
     const jigsawLink = (
       <span>
-        If you have access to Jigsaw, please login{" "}
-        <a
-          className="govuk-link lbh-link lbh-link--no-visited-state"
-          href="/jigsawLogin"
-          target="_blank"
-        >
-          here.
-        </a>
+        If you have access to Jigsaw, please login.
       </span>
     );
 

--- a/cypress/integration/4-profile.spec.ts
+++ b/cypress/integration/4-profile.spec.ts
@@ -14,7 +14,7 @@ describe('Profile', () => {
 
     it('displays jigsaw login error', ()=>{
       cy.get('.govuk-warning-text__text > :nth-child(1)').should('have.text', "Warning", {timeout: 10000});
-      cy.get('.govuk-warning-text__text > :nth-child(2)').should('have.text', "If you have access to Jigsaw, please login here.", {timeout: 10000});
+      cy.get('.govuk-warning-text__text > :nth-child(2)').should('be.visible');
     });
 
     it('displays cautionary alert warning title', ()=>{

--- a/cypress/integration/5-jigsawLogin.spec.ts
+++ b/cypress/integration/5-jigsawLogin.spec.ts
@@ -75,3 +75,24 @@ describe('jigsaw login',  () => {
  }
   
 })
+
+describe("Prompts Jigsaw login", () => {
+  before(() => {
+    cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
+    cy.clearCookie('jigsawToken');
+  });
+
+  beforeEach(() => {
+    cy.intercept("**/getJigsawCustomer**", {statusCode: 401});
+    cy.intercept('**/getJigsawCases**', {statusCode: 401});
+  })
+
+  it('displays jigsaw login link in error summary', () => {
+    cy.get('[data-testid="jigsawLoginErrorSummary"]').should('have.text', 'Log in to Jigsaw');
+  });
+
+  it('displays jigsaw login link in header bar', () => {
+    cy.get('[data-testid="jigsawloginHeader"]').should('have.text', 'Log in to Jigsaw');
+  });
+
+});

--- a/cypress/integration/7-cases.spec.ts
+++ b/cypress/integration/7-cases.spec.ts
@@ -1,48 +1,72 @@
 import { AuthRoles } from '../support/commands';
 
 describe('Cases', () => {
-  before(() => {
-    cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
-    cy.setCookie('jigsawToken', 'Placeholder-Jigsaw-Token');
+
+  describe("Prompts Jigsaw login", () => {
+    before(() => {
+      cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
+      cy.clearCookie('jigsawToken');
+    });
+
+    // beforeEach(() => {
+    //   cy.intercept("**/getJigsawCustomer**", {fixture: 'person-profile.json'});
+    //   cy.intercept('**/getJigsawCases**', {fixture: 'person-cases.json'});
+    // });
+
+    it('displays jigsaw login link in error summary', () => {
+      cy.get('[data-testid="jigsawLoginErrorSummary"]').should('have.text', 'Log in to Jigsaw');
+    });
+
+    it('displays jigsaw login link in header bar', () => {
+      cy.get('[data-testid="jigsawloginHeader"]').should('have.text', 'Log in to Jigsaw');
+    });
+
   });
 
-  beforeEach(() =>{
-  cy.intercept("**/getJigsawCustomer**", {fixture: 'person-profile.json'});
-  cy.intercept('**/getJigsawCases**', {fixture: 'person-cases.json'});
-  })
+  describe("Displays cases", () => {
+    before(() => {
+      cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
+      cy.setCookie('jigsawToken', 'Placeholder-Jigsaw-Token');
+    });
 
-  it('displays the cases tab', () => {
-    cy.get('#cases', { timeout: 10000 })
-      .should('be.visible')
-  });
-  it('displays the case ID', ()=>{
-    cy.get('[data-testid="caseId"]').should('have.text', "641056", {timeout: 10000});
-  });
-  it('displays the case Status', ()=>{
-    cy.get('[data-testid="statusName"]').should('have.text', "Relief", {timeout: 10000});
-  });
-    it('displays the case date of approach', ()=>{
-    cy.get('[data-testid="dateOfApproach"]').should('have.text', "05/05/2022 1:00", {timeout: 10000});
-  });
-  it('displays the Assigned Agent', ()=>{
-    cy.get('[data-testid="assignedTo"]').should('have.text', "Agent Carter", {timeout: 10000});
-  });
-  it('displays the Flowchart Position', ()=>{
-    cy.get('[data-testid="currentFlowChartPosition"]').should('have.text', "Relief", {timeout: 10000});
-  });
-  it('displays the current decision', ()=>{
-    cy.get('[data-testid="currentDecision"]').should('have.text', "56 days relief duty - help to secure accommodation s.189B", {timeout: 10000});
-  });
-  it('displays the placement address', ()=>{
-    cy.get('[data-testid="fullAddress"]').should('have.text', "  435 Loxford Lane Loxford Lane Ilford SW1 1AA ", {timeout: 10000});
-  });
-  it('displays the placement detail full name', ()=>{
-    cy.get('[data-testid="placementDutyFullName"]').should('have.text', "Section 188 – Interim duty to accommodate in case of apparent priority need", {timeout: 10000});
-  });
-  it('displays the additional factors', ()=>{
-    cy.get('[data-testid="AdditionalFactor-0"]').should('have.text', "Yes")
-  });
-  it('displays the health and wellbeing information', ()=>{
-    cy.get('[data-testid="WellBeingFactor-1"]').should('contain', "wheelchair/depression")
+    beforeEach(() => {
+    cy.intercept("**/getJigsawCustomer**", {fixture: 'person-profile.json'});
+    cy.intercept('**/getJigsawCases**', {fixture: 'person-cases.json'});
+    });
+
+    it('displays the cases tab', () => {
+      cy.get('#cases', { timeout: 10000 })
+        .should('be.visible')
+    });
+    it('displays the case ID', () => {
+      cy.get('[data-testid="caseId"]').should('have.text', "641056", {timeout: 10000});
+    });
+    it('displays the case Status', () => {
+      cy.get('[data-testid="statusName"]').should('have.text', "Relief", {timeout: 10000});
+    });
+      it('displays the case date of approach', () => {
+      cy.get('[data-testid="dateOfApproach"]').should('have.text', "05/05/2022 1:00", {timeout: 10000});
+    });
+    it('displays the Assigned Agent', () => {
+      cy.get('[data-testid="assignedTo"]').should('have.text', "Agent Carter", {timeout: 10000});
+    });
+    it('displays the Flowchart Position', () => {
+      cy.get('[data-testid="currentFlowChartPosition"]').should('have.text', "Relief", {timeout: 10000});
+    });
+    it('displays the current decision', () => {
+      cy.get('[data-testid="currentDecision"]').should('have.text', "56 days relief duty - help to secure accommodation s.189B", {timeout: 10000});
+    });
+    it('displays the placement address', () => {
+      cy.get('[data-testid="fullAddress"]').should('have.text', "  435 Loxford Lane Loxford Lane Ilford SW1 1AA ", {timeout: 10000});
+    });
+    it('displays the placement detail full name', () => {
+      cy.get('[data-testid="placementDutyFullName"]').should('have.text', "Section 188 – Interim duty to accommodate in case of apparent priority need", {timeout: 10000});
+    });
+    it('displays the additional factors', () => {
+      cy.get('[data-testid="AdditionalFactor-0"]').should('have.text', "Yes")
+    });
+    it('displays the health and wellbeing information', () => {
+      cy.get('[data-testid="WellBeingFactor-1"]').should('contain', "wheelchair/depression")
+    });
   });
 });

--- a/cypress/integration/7-cases.spec.ts
+++ b/cypress/integration/7-cases.spec.ts
@@ -1,72 +1,60 @@
 import { AuthRoles } from '../support/commands';
 
-describe('Cases', () => {
+describe("Displays cases", () => {
 
-  describe("Prompts Jigsaw login", () => {
-    before(() => {
-      cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
-      cy.clearCookie('jigsawToken');
-    });
-
-    // beforeEach(() => {
-    //   cy.intercept("**/getJigsawCustomer**", {fixture: 'person-profile.json'});
-    //   cy.intercept('**/getJigsawCases**', {fixture: 'person-cases.json'});
-    // });
-
-    it('displays jigsaw login link in error summary', () => {
-      cy.get('[data-testid="jigsawLoginErrorSummary"]').should('have.text', 'Log in to Jigsaw');
-    });
-
-    it('displays jigsaw login link in header bar', () => {
-      cy.get('[data-testid="jigsawloginHeader"]').should('have.text', 'Log in to Jigsaw');
-    });
-
+  before(() => {
+    cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
+    cy.setCookie('jigsawToken', 'Placeholder-Jigsaw-Token');
   });
 
-  describe("Displays cases", () => {
-    before(() => {
-      cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
-      cy.setCookie('jigsawToken', 'Placeholder-Jigsaw-Token');
-    });
-
-    beforeEach(() => {
+  beforeEach(() => {
     cy.intercept("**/getJigsawCustomer**", {fixture: 'person-profile.json'});
     cy.intercept('**/getJigsawCases**', {fixture: 'person-cases.json'});
     });
 
-    it('displays the cases tab', () => {
-      cy.get('#cases', { timeout: 10000 })
-        .should('be.visible')
-    });
-    it('displays the case ID', () => {
-      cy.get('[data-testid="caseId"]').should('have.text', "641056", {timeout: 10000});
-    });
-    it('displays the case Status', () => {
-      cy.get('[data-testid="statusName"]').should('have.text', "Relief", {timeout: 10000});
-    });
-      it('displays the case date of approach', () => {
-      cy.get('[data-testid="dateOfApproach"]').should('have.text', "05/05/2022 1:00", {timeout: 10000});
-    });
-    it('displays the Assigned Agent', () => {
-      cy.get('[data-testid="assignedTo"]').should('have.text', "Agent Carter", {timeout: 10000});
-    });
-    it('displays the Flowchart Position', () => {
-      cy.get('[data-testid="currentFlowChartPosition"]').should('have.text', "Relief", {timeout: 10000});
-    });
-    it('displays the current decision', () => {
-      cy.get('[data-testid="currentDecision"]').should('have.text', "56 days relief duty - help to secure accommodation s.189B", {timeout: 10000});
-    });
-    it('displays the placement address', () => {
-      cy.get('[data-testid="fullAddress"]').should('have.text', "  435 Loxford Lane Loxford Lane Ilford SW1 1AA ", {timeout: 10000});
-    });
-    it('displays the placement detail full name', () => {
-      cy.get('[data-testid="placementDutyFullName"]').should('have.text', "Section 188 – Interim duty to accommodate in case of apparent priority need", {timeout: 10000});
-    });
-    it('displays the additional factors', () => {
-      cy.get('[data-testid="AdditionalFactor-0"]').should('have.text', "Yes")
-    });
-    it('displays the health and wellbeing information', () => {
-      cy.get('[data-testid="WellBeingFactor-1"]').should('contain', "wheelchair/depression")
-    });
+  it('displays the cases tab', () => {
+    cy.get('#cases', { timeout: 10000 })
+      .should('be.visible')
   });
+
+  it('displays the case ID', () => {
+    cy.get('[data-testid="caseId"]').should('have.text', "641056", {timeout: 10000});
+  });
+
+  it('displays the case Status', () => {
+    cy.get('[data-testid="statusName"]').should('have.text', "Relief", {timeout: 10000});
+  });
+
+    it('displays the case date of approach', () => {
+    cy.get('[data-testid="dateOfApproach"]').should('have.text', "05/05/2022 1:00", {timeout: 10000});
+  });
+
+  it('displays the Assigned Agent', () => {
+    cy.get('[data-testid="assignedTo"]').should('have.text', "Agent Carter", {timeout: 10000});
+  });
+
+  it('displays the Flowchart Position', () => {
+    cy.get('[data-testid="currentFlowChartPosition"]').should('have.text', "Relief", {timeout: 10000});
+  });
+
+  it('displays the current decision', () => {
+    cy.get('[data-testid="currentDecision"]').should('have.text', "56 days relief duty - help to secure accommodation s.189B", {timeout: 10000});
+  });
+
+  it('displays the placement address', () => {
+    cy.get('[data-testid="fullAddress"]').should('have.text', "  435 Loxford Lane Loxford Lane Ilford SW1 1AA ", {timeout: 10000});
+  });
+
+  it('displays the placement detail full name', () => {
+    cy.get('[data-testid="placementDutyFullName"]').should('have.text', "Section 188 – Interim duty to accommodate in case of apparent priority need", {timeout: 10000});
+  });
+
+  it('displays the additional factors', () => {
+    cy.get('[data-testid="AdditionalFactor-0"]').should('have.text', "Yes")
+  });
+
+  it('displays the health and wellbeing information', () => {
+    cy.get('[data-testid="WellBeingFactor-1"]').should('contain', "wheelchair/depression")
+  });
+  
 });


### PR DESCRIPTION
"Log in to Jigsaw" always displayed on the top header when the user is not logged in to it.

"Log in to Jigsaw" added to the error message when there is a failed request to get homelessness case data on the profile view.

Clicking on either of those links appends a redirect parameter to the URL, that will bring the user back to the page they started from after logging in with Jigsaw. e.g. `http://local.hackney.gov.uk:9000/jigsawLogin?redirect=/customers/single-view/f1ce6532-80e7-4cc5-b3b8-8ea3e0a23a73`

Tests for this were put in `jigsawLogin.spec.ts`

![image](https://user-images.githubusercontent.com/74552077/183858384-e558154b-7534-4f55-a44b-6715e4b157a0.png)