### PR TITLE
Add a back button on profile page

### DIFF
--- a/apps/single-view/src/Components/BackToSearch.tsx
+++ b/apps/single-view/src/Components/BackToSearch.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { getCookie } from "../Utils";
+
+export const BackToSearch = () => {
+  const path = getCookie("searchResidentPath");
+  return (
+    <>
+      <a href={path} id={"back-to-search"} className={"govuk-back-link"}>
+        Back To Search
+      </a>
+    </>
+  );
+};

--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -13,6 +13,7 @@ import {
 import { NotFound } from "../../Components";
 import { SystemId } from "../../Interfaces/systemIdInterface";
 import { Cases } from "./Cases";
+import { BackToSearch } from "../../Components/BackToSearch";
 
 export const CustomerView = () => {
   const { dataSource, id } = useParams<UrlParams>();
@@ -111,6 +112,9 @@ export const CustomerView = () => {
       )}
       <div className="govuk-tabs lbh-tabs sv-space-t" data-module="govuk-tabs">
         <h2 className="govuk-tabs__title">Contents</h2>
+
+        <BackToSearch />
+
         <ul className="govuk-tabs__list">
           <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
             <a className="govuk-tabs__tab" href="#profile">

--- a/apps/single-view/src/Views/SearchView/searchByResident.tsx
+++ b/apps/single-view/src/Views/SearchView/searchByResident.tsx
@@ -114,6 +114,8 @@ export const SearchByResident = (props: myProps): JSX.Element => {
                   path += `&dateOfBirth=${dateOfBirth}`;
                 }
                 history.push(path);
+
+                window.document.cookie = `searchResidentPath=${path}`;
               }
             }}
           >

--- a/cypress/integration/8-backToSearch.spec.ts
+++ b/cypress/integration/8-backToSearch.spec.ts
@@ -1,0 +1,26 @@
+import { AuthRoles } from '../support/commands';
+
+describe('Profile', () => {
+    describe('Basic Information', () => {
+        before(() => {
+            cy.intercept('GET', '**/customers*', { fixture: 'person-profile.json' }).as('getPerson');
+            cy.visitAs('/customers/single-view/6d7ed1a4', AuthRoles.UnrestrictedGroup);
+            cy.setCookie('jigsawToken', 'testValue')
+            cy.setCookie('searchResidentPath', '/search?firstName=Luna&lastName=Kitty');
+        })
+
+        it('displays the Back to search button', () => {
+            cy.get('#back-to-search', { timeout: 10000 }).should('be.visible');
+
+            cy.get('#back-to-search').first().click({ force: true });
+            
+            cy.location().should((location) => {
+                expect(location.pathname).to.eq('/search');
+                expect(location.search).to.eq('?firstName=Luna&lastName=Kitty');
+            });
+
+            cy.get('#firstName').should('have.value', 'Luna');
+            cy.get('#lastName').should('have.value', 'Kitty');
+        });
+    });
+})


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/284WnpwN/277-back-to-search-button-to-return-from-profile-view

## Describe this PR
### What is the problem we're trying to solve
Currently there is no back button to take user to search results from the profile page.

### What changes have we introduced
Add a back button on top of the profile page that takes user directly to the search results page, loading search results with input fields filled in as before. 

#### Checklist
- [x] Added tests to cover all new production code

#### Screenshots
<img width="1440" alt="Screenshot 2022-08-10 at 12 42 05 pm" src="https://user-images.githubusercontent.com/31739633/183894157-48b42922-82d2-44a4-a656-2fb301c0a9f8.png">


