### PR TITLE
Logout of jigsaw button

### DIFF
--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -6,6 +6,8 @@ import { Link, PhaseBanner } from "@mfe/common/lib/components";
 
 import { locale } from "./services";
 
+import Cookies from "js-cookie";
+
 const {
   welcome,
   signIn,
@@ -74,17 +76,20 @@ const App = (): JSX.Element => {
                   <p>
                     {welcome} <b>{auth.name}</b>
                   </p>
+                  {/* Jigsaw Login & Logout */}
                   {(document.cookie.indexOf("jigsawToken") == -1) ? (
-                  <RouterLink to={jigsawLoginLink + "?redirect=" + window.location.pathname} data-testid="jigsawloginHeader">
+                  <RouterLink to={jigsawLoginLink + "?redirect=" + window.location.pathname} data-testid="jigsawLoginHeader">
                     {loginJigsaw}
                   </RouterLink>
                    ) : 
                   <Link as="button" onClick={() => {
-                    document.cookie = "jigsawToken" +'=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-                    window.location.href = window.location.pathname;
-                  }} className="lbh-signout">
+                    // Removes token cookie by making it expire in the past & Refreshes page to take effect
+                    Cookies.remove("jigsawToken");
+                    window.location.reload();
+                  }} className="lbh-signout" data-testid="jigsawLogoutHeader">
                     {logoutJigsaw}
                   </Link>}
+
                   <Link as="button" onClick={() => logout()} className="lbh-signout">
                     {signOut}
                   </Link>

--- a/apps/header/src/app.tsx
+++ b/apps/header/src/app.tsx
@@ -11,6 +11,7 @@ const {
   signIn,
   signOut,
   loginJigsaw,
+  logoutJigsaw,
   jigsawLoginLink,
   branding: { hackney, manageMyHome },
 } = locale;
@@ -73,11 +74,17 @@ const App = (): JSX.Element => {
                   <p>
                     {welcome} <b>{auth.name}</b>
                   </p>
-                  {(document.cookie.indexOf("jigsawToken") == -1) &&
+                  {(document.cookie.indexOf("jigsawToken") == -1) ? (
                   <RouterLink to={jigsawLoginLink + "?redirect=" + window.location.pathname} data-testid="jigsawloginHeader">
                     {loginJigsaw}
                   </RouterLink>
-                  }
+                   ) : 
+                  <Link as="button" onClick={() => {
+                    document.cookie = "jigsawToken" +'=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                    window.location.href = window.location.pathname;
+                  }} className="lbh-signout">
+                    {logoutJigsaw}
+                  </Link>}
                   <Link as="button" onClick={() => logout()} className="lbh-signout">
                     {signOut}
                   </Link>

--- a/apps/header/src/services/locale.ts
+++ b/apps/header/src/services/locale.ts
@@ -3,6 +3,7 @@ const locale = {
   signOut: "Sign out",
   signIn: "Sign in",
   loginJigsaw: "Log in to Jigsaw",
+  logoutJigsaw: "Log out of Jigsaw",
   jigsawLoginLink: "/jigsawLogin",
   branding: {
     hackney: "Hackney",

--- a/apps/single-view/src/Components/JigsawLogin.tsx
+++ b/apps/single-view/src/Components/JigsawLogin.tsx
@@ -33,7 +33,7 @@ export const JigsawLogin = () => {
           let date = new Date();
           date.setTime(date.getTime() + 10 * 60 * 60 * 1000);
 
-          Cookies.set("jigsawToken", `${token}`, {path: "/", expires: date})
+          Cookies.set("jigsawToken", `${token}`, { path: "/", expires: date });
 
           const params = new URLSearchParams(window.location.search);
           const redirectUrl = params.get("redirect");

--- a/apps/single-view/src/Components/JigsawLogin.tsx
+++ b/apps/single-view/src/Components/JigsawLogin.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 import { authoriseJigsaw } from "../Gateways/Jigsaw";
 import { Input } from "./index";
 
+import Cookies from "js-cookie";
+
 export const JigsawLogin = () => {
   const [username, setUsername] = useState<string>();
   const [password, setPassword] = useState<string>();
@@ -30,8 +32,8 @@ export const JigsawLogin = () => {
         .then((token) => {
           let date = new Date();
           date.setTime(date.getTime() + 10 * 60 * 60 * 1000);
-          document.cookie = `jigsawToken=${token}; expires=${date.toUTCString()}`;
-          document.cookie = `jigsawDismissed=false; expires=${date.toUTCString()}`;
+
+          Cookies.set("jigsawToken", `${token}`, {path: "/", expires: date})
 
           const params = new URLSearchParams(window.location.search);
           const redirectUrl = params.get("redirect");

--- a/cypress/integration/5-jigsawLogin.spec.ts
+++ b/cypress/integration/5-jigsawLogin.spec.ts
@@ -1,98 +1,114 @@
 import { AuthRoles } from '../support/commands';
 
-describe('jigsaw login',  () => {
-  
-  before(() => {
-    cy.visitAs('/', AuthRoles.UnrestrictedGroup);
+describe('Jigsaw Login & Logout',  () => {
+
+  describe('Performs Jigsaw login',  () => {
+    
+    before(() => {
+      cy.visitAs('/', AuthRoles.UnrestrictedGroup);
+    })
+
+    it('displays the heading', () => {
+      cy.get('.lbh-heading-h1', { timeout: 10000 })
+        .should('be.visible')
+        .should('have.text', 'Login to your Jigsaw account')
+    });
+
+    it('displays dismiss link', () => {
+      cy.get('[data-testid="dismiss-jigsaw-login"]').should('have.text', "I don’t have access to Jigsaw.");
+    });
+
+    it('displays the form', () => {
+      cy.get('form').contains('Username');
+      cy.get('form').contains('Password');
+    });
+
+    it('displays the error messages', () => {
+      cy.get('.govuk-button', { timeout: 10000 }).click();
+
+      cy.contains('Username is mandatory');
+      cy.contains('Password is mandatory');
+    });
+
+    it('cookie is set when logged in', () => {
+      cy.get('#username', { timeout: 10000 }).type('Luna');
+      cy.get('#password').type('pa$$w0rd');
+
+      const someThing = "Placeholder-Jigsaw-Token";
+
+      cy.intercept('**/storeCredentials', {body: someThing});
+
+      cy.get('.govuk-button').should('have.text', 'Login').click().then(() => {
+        cy.getCookie('jigsawToken')
+            .should('have.property', 'value', someThing);
+      });
+    })
+  if (Cypress.env('APP_ENV') == 'production') {
+      it('displays displays error when creds are wrong', ()=> {
+      cy.visitAs('/jigsawLogin', AuthRoles.UnrestrictedGroup);
+
+      cy.get('#username').type('Luna');
+      cy.get('#password').type('pa$$w0rd');
+
+      cy.intercept('POST', '**/storeCredentials', {
+        statusCode: 401,
+      }).as('submitWrongCreds'); 
+
+      cy.get('.govuk-button').should('have.text', 'Login').click().then(() => {
+        cy.get('.govuk-error-summary').should('be.visible').should('have.text', 'There is a problemPlease ensure that you have entered your credentials correctly')
+      });
+    });
+
+    describe('when user dismisses login', ()=>{
+      it('dismissed cookie is set', () => {
+        cy.get('[data-testid="dismiss-jigsaw-login"]').should('have.text', "I don’t have access to Jigsaw.")
+            .click().then(() => {
+              cy.getCookie('jigsawDismissed')
+                  .should('have.property', 'value', 'true');
+            });
+      });
+
+      it('redirects to search', () => {
+        cy.location().should((location) => {
+          expect(location.pathname).to.eq('/search')
+        })
+      });
+    });
+  }
+    
   })
 
-  it('displays the heading', () => {
-    cy.get('.lbh-heading-h1', { timeout: 10000 })
-      .should('be.visible')
-      .should('have.text', 'Login to your Jigsaw account')
-  });
-
-  it('displays dismiss link', () => {
-    cy.get('[data-testid="dismiss-jigsaw-login"]').should('have.text', "I don’t have access to Jigsaw.");
-  });
-
-  it('displays the form', () => {
-    cy.get('form').contains('Username');
-    cy.get('form').contains('Password');
-  });
-
-  it('displays the error messages', () => {
-    cy.get('.govuk-button', { timeout: 10000 }).click();
-
-    cy.contains('Username is mandatory');
-    cy.contains('Password is mandatory');
-  });
-
-  it('cookie is set when logged in', () => {
-    cy.get('#username', { timeout: 10000 }).type('Luna');
-    cy.get('#password').type('pa$$w0rd');
-
-    const someThing = "Placeholder-Jigsaw-Token";
-
-    cy.intercept('**/storeCredentials', {body: someThing});
-
-    cy.get('.govuk-button').should('have.text', 'Login').click().then(() => {
-      cy.getCookie('jigsawToken')
-          .should('have.property', 'value', someThing);
+  describe("Prompts Jigsaw login", () => {
+    before(() => {
+      cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
+      cy.clearCookie('jigsawToken');
     });
+
+    beforeEach(() => {
+      cy.intercept("**/getJigsawCustomer**", {statusCode: 401});
+      cy.intercept('**/getJigsawCases**', {statusCode: 401});
+    })
+
+    it('displays jigsaw login link in error summary', () => {
+      cy.get('[data-testid="jigsawLoginErrorSummary"]').should('have.text', 'Log in to Jigsaw');
+    });
+
+    it('displays jigsaw login link in header bar', () => {
+      cy.get('[data-testid="jigsawLoginHeader"]').should('have.text', 'Log in to Jigsaw');
+    });
+
+  });
+
+  describe("Performs Jigsaw logout", () =>{
+    before(() => {
+      cy.visitAs('/search', AuthRoles.UnrestrictedGroup);
+      cy.setCookie('jigsawToken', 'testValue')
+    });
+
+    it('performs jigsaw logout', () => {
+      cy.get('[data-testid="jigsawLogoutHeader"]').click()
+      cy.getCookie('jigsawToken').should('not.exist')
+    })
   })
- if (Cypress.env('APP_ENV') == 'production') {
-    it('displays displays error when creds are wrong', ()=> {
-    cy.visitAs('/jigsawLogin', AuthRoles.UnrestrictedGroup);
-
-    cy.get('#username').type('Luna');
-    cy.get('#password').type('pa$$w0rd');
-
-    cy.intercept('POST', '**/storeCredentials', {
-      statusCode: 401,
-    }).as('submitWrongCreds'); 
-
-    cy.get('.govuk-button').should('have.text', 'Login').click().then(() => {
-      cy.get('.govuk-error-summary').should('be.visible').should('have.text', 'There is a problemPlease ensure that you have entered your credentials correctly')
-    });
-  });
-
-  describe('when user dismisses login', ()=>{
-    it('dismissed cookie is set', () => {
-      cy.get('[data-testid="dismiss-jigsaw-login"]').should('have.text', "I don’t have access to Jigsaw.")
-          .click().then(() => {
-            cy.getCookie('jigsawDismissed')
-                .should('have.property', 'value', 'true');
-          });
-    });
-
-    it('redirects to search', () => {
-      cy.location().should((location) => {
-        expect(location.pathname).to.eq('/search')
-      })
-    });
-  });
- }
-  
-})
-
-describe("Prompts Jigsaw login", () => {
-  before(() => {
-    cy.visitAs('/customers/Jigsaw/641056#cases', AuthRoles.UnrestrictedGroup);
-    cy.clearCookie('jigsawToken');
-  });
-
-  beforeEach(() => {
-    cy.intercept("**/getJigsawCustomer**", {statusCode: 401});
-    cy.intercept('**/getJigsawCases**', {statusCode: 401});
-  })
-
-  it('displays jigsaw login link in error summary', () => {
-    cy.get('[data-testid="jigsawLoginErrorSummary"]').should('have.text', 'Log in to Jigsaw');
-  });
-
-  it('displays jigsaw login link in header bar', () => {
-    cy.get('[data-testid="jigsawloginHeader"]').should('have.text', 'Log in to Jigsaw');
-  });
 
 });


### PR DESCRIPTION
When the user is logged in with Jigsaw (and have a `jigsawToken` cookie), they should see a Log out of Jigsaw button in the header bar.
This will set the cookie's expiry date to the past and refresh the page, which effectively deletes the cookie.

A dedicated function for cookie management was imported and used instead of using `document.cookie` - seems to work more reliably? There were some times when the button didn't work without clear reason before.

![image](https://user-images.githubusercontent.com/74552077/184342872-0b870f5f-36ea-439d-b406-d907b6092d54.png)
