### PR TITLE
Add active jigsaw case reference to Active-Homelessness-Case tab

### DIFF
--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -23,7 +23,7 @@ export const CustomerView = () => {
   const [dataSourceError, setDataSourceError] =
     useState<Array<SystemId> | null>();
   const [systemIds, setSystemIds] = useState<Array<SystemId>>();
-  const nullOrEmpty = (item: string): boolean => item == null || item == "";
+  const isNullOrEmpty = (item: string): boolean => item == null || item == "";
 
   const loadPerson = async (): Promise<customerResponse | null> => {
     try {
@@ -117,7 +117,8 @@ export const CustomerView = () => {
           </li>
           <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
             <a className="govuk-tabs__tab" href="#cases">
-              Active Homelessness Case
+              Active Homelessness Case{" "}
+              {isNullOrEmpty(jigsawId) ? "" : `(${jigsawId})`}
             </a>
           </li>
         </ul>
@@ -132,7 +133,7 @@ export const CustomerView = () => {
           />
         </section>
         <section className="govuk-tabs__panel" id="cases">
-          {nullOrEmpty(jigsawId) ? (
+          {isNullOrEmpty(jigsawId) ? (
             <p
               className="govuk-inset-text lbh-inset-text"
               data-testid="homelessnessCasesNotFound"

--- a/cypress/integration/7-cases.spec.ts
+++ b/cypress/integration/7-cases.spec.ts
@@ -16,6 +16,10 @@ describe("Displays cases", () => {
     cy.get('#cases', { timeout: 10000 })
       .should('be.visible')
   });
+  
+  it('displays the cases tab with jigsaw id when available', () => {
+    cy.get('#tab_cases').should('have.text', "Active Homelessness Case (641056)", {timeout: 10000});
+  });
 
   it('displays the case ID', () => {
     cy.get('[data-testid="caseId"]').should('have.text', "641056", {timeout: 10000});


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/PTmw106E/292-add-case-reference-number-from-jigsaw

## Describe this PR
### What is the problem we're trying to solve
Currently active jigsaw case id is not visible unless a user clicks on a Active-Homelessness-Case tab.

### What changes have we introduced
When an active jigsaw case is available, id is displayed on Active-Homelessness-Case tab.

#### Checklist
- [x] Added tests to cover all new production code

#### Screenshots
<img width="998" alt="Screenshot 2022-08-15 at 2 30 28 pm" src="https://user-images.githubusercontent.com/31739633/184658878-d0fb69fc-e246-4772-86d1-95e87c5bc4be.png">

