### PR TITLE
Remove misleading message before loading homelessness cases

### DIFF
--- a/apps/single-view/src/Views/CustomerView/Cases.tsx
+++ b/apps/single-view/src/Views/CustomerView/Cases.tsx
@@ -29,7 +29,7 @@ export const Cases = (props: Props): JSX.Element => {
   };
 
   useEffect(() => {
-    if (props.customerId) {
+    if (props.customerId && props.customerId !== "jigsaw id not found") {
       loadCases(props.customerId);
     }
   }, [props.customerId]);
@@ -66,11 +66,31 @@ export const Cases = (props: Props): JSX.Element => {
     );
   }
 
-  if (typeof cases == "undefined") {
+  if (getCasesError) {
+    return (
+      <ErrorSummary
+        id="singleViewNotesError"
+        title="Error"
+        description="Unable to load cases."
+        children={jigsawTokenMessage}
+      />
+    );
+  }
+
+  if (props.customerId == "") {
     return (
       <Center>
         <Spinner />
       </Center>
+    );
+  } else if (props.customerId == "jigsaw id not found") {
+    return (
+      <p
+        className="govuk-inset-text lbh-inset-text"
+        data-testid="homelessnessCasesNotFound"
+      >
+        There were no active homelessness cases found for this customer.
+      </p>
     );
   }
 
@@ -78,9 +98,9 @@ export const Cases = (props: Props): JSX.Element => {
     return cases != null ? (
       <CaseSummary jigsawCaseResponse={cases} />
     ) : (
-      <div className="govuk-inset-text lbh-inset-text" data-testid="notFound">
-        There were no active homelessness cases found for this customer.
-      </div>
+      <Center>
+        <Spinner />
+      </Center>
     );
   }
 };

--- a/apps/single-view/src/Views/CustomerView/index.tsx
+++ b/apps/single-view/src/Views/CustomerView/index.tsx
@@ -37,7 +37,9 @@ export const CustomerView = () => {
         var jigsawId = person?.systemIds.find(
           (id: SystemId) => id.systemName == Jigsaw
         );
-        if (jigsawId) setJigsawId(jigsawId.id);
+        jigsawId
+          ? setJigsawId(jigsawId.id)
+          : setJigsawId("jigsaw id not found");
       }
 
       var mmhId = person?.systemIds?.find(
@@ -118,7 +120,9 @@ export const CustomerView = () => {
           <li className="govuk-tabs__list-item govuk-tabs__list-item--selected">
             <a className="govuk-tabs__tab" href="#cases">
               Active Homelessness Case{" "}
-              {isNullOrEmpty(jigsawId) ? "" : `(${jigsawId})`}
+              {isNullOrEmpty(jigsawId) || jigsawId == "jigsaw id not found"
+                ? ""
+                : `(${jigsawId})`}
             </a>
           </li>
         </ul>
@@ -133,16 +137,7 @@ export const CustomerView = () => {
           />
         </section>
         <section className="govuk-tabs__panel" id="cases">
-          {isNullOrEmpty(jigsawId) ? (
-            <p
-              className="govuk-inset-text lbh-inset-text"
-              data-testid="homelessnessCasesNotFound"
-            >
-              There were no active homelessness cases found for this customer.
-            </p>
-          ) : (
-            <Cases customerId={jigsawId} />
-          )}
+          <Cases customerId={jigsawId} />
         </section>
       </div>
     </>


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/XVnSJ6Uz/312-there-were-no-active-homelessness-cases-found-for-this-customer-shown-on-active-homelessness-case-tab-before-information-loads

## Describe this PR
### What is the problem we're trying to solve
Currently, "There were no active homelessness cases found for this customer" shown on Active Homelessness Case tab before information loads. Instead, a user should see a spinner until the information is loaded and see the message only when there are no cases found. 

### What changes have we introduced
The error message is visible only when cases are not available 

#### Screen recording 

https://user-images.githubusercontent.com/31739633/185146918-691b63c9-3e24-4bc6-97d2-884c3d4f3e95.mov