### PR TITLE
Rearrange merged records on search results page

### DIFF
--- a/apps/single-view/src/Components/SearchResultsGroup.tsx
+++ b/apps/single-view/src/Components/SearchResultsGroup.tsx
@@ -17,77 +17,97 @@ export const SearchResultsGroup = (props: Props): JSX.Element => {
   return (
     <>
       {props.results.map((person: housingSearchPerson, index: number) => {
+        const mergedRecord = person.dataSource == SingleView;
+
+        const dataSourceId = (
+          <span>
+            {humanize(person.dataSource)} ID: {person.id} <br />
+          </span>
+        );
+
+        const niNumberForMergedRecords = isNullOrEmpty(person.niNumber) ? (
+          ""
+        ) : (
+          <span>
+            NI Number: {person.niNumber} <br />
+          </span>
+        );
+
+        const niNumberForUnmergedRecords = isNullOrEmpty(person.niNumber) ? (
+          <span>
+            (NI Number Not Set) <br />
+          </span>
+        ) : (
+          <span>
+            NI Number: {person.niNumber} <br />
+          </span>
+        );
+
+        const address =
+          person.knownAddresses?.length > 0 ? (
+            person.knownAddresses.map((address) => {
+              return (
+                <span>
+                  {" "}
+                  {address.fullAddress} <br />{" "}
+                </span>
+              );
+            })
+          ) : (
+            <span>
+              (Address Not Set) <br />
+            </span>
+          );
+
         return (
           <>
             <div className="lbh-body sv-result-wrapper" key={index}>
-              {person.dataSource != "single-view" ? (
-                <div className="govuk-checkboxes lbh-checkboxes">
-                  <div className="govuk-checkboxes_item">
-                    <input
-                      className="govuk-checkboxes_input sv-checkboxes"
-                      id={`match-${person.id}`}
-                      name="match"
-                      type="checkbox"
-                      value="match"
-                      aria-label="match-checkbox"
-                      checked={person.isSelected}
-                      onChange={() => props.selectMatch(person)}
-                    />
+              <div className="sv-result-sub-wrapper">
+                {!mergedRecord && (
+                  <div className="govuk-checkboxes lbh-checkboxes">
+                    <div className="govuk-checkboxes_item">
+                      <input
+                        className="govuk-checkboxes_input sv-checkboxes"
+                        id={`match-${person.id}`}
+                        name="match"
+                        type="checkbox"
+                        value="match"
+                        aria-label="match-checkbox"
+                        checked={person.isSelected}
+                        onChange={() => props.selectMatch(person)}
+                      />
+                    </div>
                   </div>
-                </div>
-              ) : (
-                <div
-                  className="govuk-checkboxes lbh-checkboxes"
-                  style={{ visibility: "hidden" }}
-                >
-                  <div className="govuk-checkboxes_item">
-                    <input
-                      className="govuk-checkboxes_input sv-checkboxes"
-                      id={`match-${person.id}`}
-                      name="match"
-                      type="checkbox"
-                      value="match"
-                      aria-label="match-checkbox"
-                      checked={person.isSelected}
-                      onChange={() => props.selectMatch(person)}
-                    />
-                  </div>
-                </div>
-              )}
-              <div className="sv-result">
-                {person.dataSource == "single-view" ? (
-                  <strong className="lbh-tag lbh-tag--green">Merged</strong>
-                ) : (
-                  <strong className="lbh-tag lbh-tag--grey">Unmerged</strong>
                 )}
-                &nbsp;
-                <a
-                  href={`/customers/${person.dataSource}/${person.id}`}
-                  className="lbh-link lbh-link--no-visited-state"
-                >
-                  {person.firstName} {person.surName}
-                  {person.dateOfBirth &&
-                    ", Date of Birth: " + formatDate(person.dateOfBirth)}
-                </a>
-                <div className="lbh-body-s govuk-!-margin-top-1">
-                  {humanize(person.dataSource)} ID: {person.id}
-                  <br />
-                  {isNullOrEmpty(person.niNumber)
-                    ? "(NI Number Not Set)"
-                    : `NI Number: ${person.niNumber}`}{" "}
-                  <br />
-                  {person.knownAddresses?.length > 0
-                    ? person.knownAddresses.map((address) => {
-                        return address.fullAddress + " ";
-                      })
-                    : "(Address Not Set)"}
-                  <br />
-                  <strong className="lbh-tag lbh-tag--grey">
-                    {humanize(person.dataSource)}
-                  </strong>
+                <div className="sv-result">
+                  {mergedRecord ? (
+                    <strong className="lbh-tag lbh-tag--green">Merged</strong>
+                  ) : (
+                    <strong className="lbh-tag lbh-tag--grey">Unmerged</strong>
+                  )}
+                  &nbsp;
+                  <a
+                    href={`/customers/${person.dataSource}/${person.id}`}
+                    className="lbh-link lbh-link--no-visited-state"
+                  >
+                    {person.firstName} {person.surName}
+                    {person.dateOfBirth &&
+                      ", Date of Birth: " + formatDate(person.dateOfBirth)}
+                  </a>
+                  <div className="lbh-body-s govuk-!-margin-top-1">
+                    {!mergedRecord && dataSourceId}
+                    {mergedRecord
+                      ? niNumberForMergedRecords
+                      : niNumberForUnmergedRecords}
+                    {!mergedRecord && address}
+                    <strong className="lbh-tag lbh-tag--grey">
+                      {humanize(person.dataSource)}
+                    </strong>
+                  </div>
                 </div>
               </div>
-              {person.dataSource == SingleView && (
+
+              {mergedRecord && (
                 <UnmergeRecordButton
                   svId={person.id}
                   setUnmergeError={props.setUnmergeError}

--- a/apps/single-view/src/Views/SearchView/searchResults.tsx
+++ b/apps/single-view/src/Views/SearchView/searchResults.tsx
@@ -37,12 +37,19 @@ export const SearchResults = (props: myProps): JSX.Element => {
   const [mergeError, setMergeError] = useState<string | null>(null);
   const [unMergeError, setUnmergeError] = useState<string | null>(null);
 
+  const mergedRecords = props.matchedResults?.filter(
+    (matchedResult) => matchedResult.dataSource == "single-view"
+  );
+  const matchedResultsWithoutMergedRecords = props.matchedResults?.filter(
+    (matchedResult) => matchedResult.dataSource !== "single-view"
+  );
+
   useEffect(() => {
     setMergeError(null);
     setUnmergeError(null);
     setResults(sliceIntoChunks(props.otherResults, props.maxSearchResults)[0]);
     setSelectedRecords([]);
-    setMatchedResults(props.matchedResults);
+    setMatchedResults(matchedResultsWithoutMergedRecords);
   }, [props.otherResults, props.matchedResults, props.maxSearchResults]);
 
   const onPageChange = (currentPage: number, isNext: boolean) => {
@@ -126,6 +133,21 @@ export const SearchResults = (props: myProps): JSX.Element => {
           />
         )}
         <hr />
+
+        <div id="mergedRecords">
+          {mergedRecords &&
+            mergedRecords.length > 0 && [
+              <h4 className="lbh-heading-h4">
+                The following results were merged and saved in single view:
+              </h4>,
+              <SearchResultsGroup
+                results={mergedRecords}
+                selectMatch={selectMatch}
+                setUnmergeError={displayUnmergeError}
+              />,
+            ]}
+        </div>
+
         <div id="matchedResults">
           {matchedResults &&
             matchedResults.length > 0 && [

--- a/apps/single-view/src/app.scss
+++ b/apps/single-view/src/app.scss
@@ -90,5 +90,6 @@ $lbh-asset-path: "../node_modules/lbh-frontend/dist/assets";
 }
 
 .sv-unmerge-button {
+  margin-top: 0 !important;
   margin-bottom: auto !important;
 }

--- a/apps/single-view/src/app.scss
+++ b/apps/single-view/src/app.scss
@@ -51,6 +51,12 @@ $lbh-asset-path: "../node_modules/lbh-frontend/dist/assets";
 .sv-result-wrapper {
   display: flex;
   flex-direction: row;
+  justify-content: space-between;
+}
+
+.sv-result-sub-wrapper {
+  display: flex;
+  flex-direction: row;
 }
 
 .sv-result {

--- a/cypress/fixtures/person-search.json
+++ b/cypress/fixtures/person-search.json
@@ -52,6 +52,32 @@
                         "currentAddress": true
                     }
                 ]
+            },
+            {
+                "id": "a1e2a970",
+                "title": "Mr",
+                "firstName": "Leo",
+                "middleName": null,
+                "surName": "Kitty",
+                "dataSource": "single-view",
+                "preferredFirstname": "Leo",
+                "preferredSurname": "Kitty",
+                "totalBalance": 0.0,
+                "dateOfBirth": "1970-02-18",
+                "personTypes": [
+                    "Tenant"
+                ],
+                "isPersonCautionaryAlert": false,
+                "isTenureCautionaryAlert": false,
+                "knownAddresses": [
+                    {
+                        "id": "d43caa5b",
+                        "startDate": "2004-12-13",
+                        "endDate": null,
+                        "fullAddress": "10 Kingston Road, KT1 2EE",
+                        "currentAddress": true
+                    }
+                ]
             }
         ],
         "ungroupedResults": [

--- a/cypress/integration/2-search.spec.ts
+++ b/cypress/integration/2-search.spec.ts
@@ -53,14 +53,14 @@ describe('search', () => {
     cy.get('#searchResults', { timeout: 10000 })
       .should('be.visible')
 
-    cy.get('.lbh-heading-h3').should('have.text', '14 results found')
+    cy.get('.lbh-heading-h3').should('have.text', '15 results found')
 
-    cy.get('.lbh-heading-h4').first().should('have.text', 'The following results were matched on name and date of birth, if provided:')
-
-    cy.get('.sv-result').first()
-      .contains('Olivia Kitty');
+    cy.get('.lbh-heading-h4').first().should('have.text', 'The following results were merged and saved in single view:')
 
     cy.get('.sv-result').first()
+      .contains('Leo Kitty');
+
+    cy.get('.sv-result').eq(1)
         .contains('(NI Number Not Set)');
   });
 

--- a/cypress/integration/3-match.spec.js
+++ b/cypress/integration/3-match.spec.js
@@ -17,16 +17,10 @@ describe('matching', () => {
     cy.get('#searchResults', { timeout: 10000 })
       .should('be.visible')
 
-    cy.get('.lbh-heading-h3').should('have.text', '14 results found')
+    cy.get('.lbh-heading-h3').should('have.text', '15 results found')
 
     cy.get('.sv-result').first()
-      .contains('Olivia Kitty');
-  });
-
-  it('does not display merge option for single view records', () => {
-    cy.get(".sv-checkboxes").eq(0).should('exist');
-    cy.get(".sv-checkboxes").eq(1).should('exist');
-    cy.get('#searchResults > :nth-child(4) > .govuk-checkboxes').should('not.be.visible');
+      .contains('Leo Kitty');
   });
 
  it('allows user to match results', () => {


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/AFXg8w0u/317-address-not-set-on-all-merged-records

## Describe this PR
### What is the problem we're trying to solve
There are no addresses displayed for the merged records on search results. Instead it shows - **Address Not Set**, it could be misleading as address history is found on clicking that record. 

### What changes have we introduced
- Separated Merged records and displayed at the top of the search results.
- Remove single view id and address from Merged records on search results page.
- Display NI number only if it's available.
- Realign the unmerge button to right side.

#### Checklist
- [x] Added tests to cover all new production code

#### Screenshot 
<img width="1440" alt="Screenshot 2022-08-19 at 11 58 09 am" src="https://user-images.githubusercontent.com/31739633/185609360-c3b17bef-2e3c-4295-bcfe-1041046decec.png">
