### PR TITLE
Display jigsaw-cases-not-found message for jigsaw customers without cases

### DIFF
--- a/apps/single-view/src/Views/CustomerView/Cases.tsx
+++ b/apps/single-view/src/Views/CustomerView/Cases.tsx
@@ -12,6 +12,7 @@ interface Props {
 export const Cases = (props: Props): JSX.Element => {
   const [cases, setCases] = useState<jigsawCasesResponse | null>(null);
   const [getCasesError, setGetCasesError] = useState<boolean>(false);
+  const [casesNotFoundError, setCasesNotFoundError] = useState<boolean>(false);
 
   const loadCases = async (customerId: string): Promise<void> => {
     setGetCasesError(false);
@@ -22,7 +23,9 @@ export const Cases = (props: Props): JSX.Element => {
       );
       setCases(cases);
     } catch (e: any) {
-      if (e.response.status != 404) {
+      if (e.response.status == 404) {
+        setCasesNotFoundError(true);
+      } else {
         setGetCasesError(true);
       }
     }
@@ -65,14 +68,14 @@ export const Cases = (props: Props): JSX.Element => {
     );
   }
 
-  if (getCasesError) {
+  if (casesNotFoundError || props.customerId == "jigsaw id not found") {
     return (
-      <ErrorSummary
-        id="singleViewNotesError"
-        title="Error"
-        description="Unable to load cases."
-        children={jigsawTokenMessage}
-      />
+      <p
+        className="govuk-inset-text lbh-inset-text"
+        data-testid="homelessnessCasesNotFound"
+      >
+        There were no active homelessness cases found for this customer.
+      </p>
     );
   }
 
@@ -81,15 +84,6 @@ export const Cases = (props: Props): JSX.Element => {
       <Center>
         <Spinner />
       </Center>
-    );
-  } else if (props.customerId == "jigsaw id not found") {
-    return (
-      <p
-        className="govuk-inset-text lbh-inset-text"
-        data-testid="homelessnessCasesNotFound"
-      >
-        There were no active homelessness cases found for this customer.
-      </p>
     );
   }
 


### PR DESCRIPTION
## Describe this PR
### What is the problem we're trying to solve
Currently, if user is logged in to Jigsaw and a jigsaw resident does not have cases than the loading spinner spins indefinitely. 

### What changes have we introduced
Display a message that the resident does not have cases instead of never disappearing loading spinner. 