### PR TITLE
Add unmerge confirmation and cancel buttons

### DIFF
--- a/apps/single-view/src/Components/SearchResultsGroup.tsx
+++ b/apps/single-view/src/Components/SearchResultsGroup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { formatDate } from "@mfe/common/lib/utils";
 import { housingSearchPerson } from "../Interfaces";
 import { UnmergeRecordButton } from "./UnmergeRecordButton";
@@ -14,6 +14,8 @@ interface Props {
 }
 
 export const SearchResultsGroup = (props: Props): JSX.Element => {
+  const [unmergeRecordPersonId, setUnmergeRecordPersonId] = useState<string>();
+
   const isNullOrEmpty = (data: string | null): boolean =>
     data == null || data == "";
 
@@ -21,6 +23,8 @@ export const SearchResultsGroup = (props: Props): JSX.Element => {
     <>
       {props.results.map((person: housingSearchPerson, index: number) => {
         const mergedRecord = isMergedRecord(person);
+        let recordWithUnmergeRecordPersonId: boolean =
+          person.id == unmergeRecordPersonId;
 
         const dataSourceId = (
           <span>
@@ -127,10 +131,23 @@ export const SearchResultsGroup = (props: Props): JSX.Element => {
                 </div>
               </div>
 
-              {mergedRecord && (
+              {mergedRecord && !recordWithUnmergeRecordPersonId && (
+                <button
+                  onClick={() => {
+                    setUnmergeRecordPersonId(person.id);
+                  }}
+                  className="govuk-button govuk-button--warning sv-unmerge-button"
+                  data-testid="unmerge"
+                >
+                  Unmerge
+                </button>
+              )}
+
+              {mergedRecord && recordWithUnmergeRecordPersonId && (
                 <UnmergeRecordButton
                   svId={person.id}
                   setUnmergeError={props.setUnmergeError}
+                  unmergeRecordPersonId={setUnmergeRecordPersonId}
                 />
               )}
             </div>

--- a/apps/single-view/src/Components/UnmergeRecordButton.tsx
+++ b/apps/single-view/src/Components/UnmergeRecordButton.tsx
@@ -4,6 +4,7 @@ import { unmergeRecords } from "../Gateways/recordsGateway";
 interface Props {
   svId: string;
   setUnmergeError: () => void;
+  unmergeRecordPersonId: (id: string) => void;
 }
 
 //component to unmerge
@@ -38,14 +39,25 @@ export const UnmergeRecordButton: React.FC<Props> = (props) => {
       </svg>
     </div>
   ) : (
-    <button
-      onClick={() => {
-        deleteRecord();
-      }}
-      className="govuk-button lbh-button govuk-button--start sv-unmerge-button"
-    >
-      Unmerge
-      <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-    </button>
+    <div className="sv-buttons-wrapper">
+      <button
+        onClick={() => {
+          deleteRecord();
+        }}
+        className="govuk-button govuk-button--warning sv-unmerge-button"
+        data-testid="confirm"
+      >
+        Confirm
+      </button>
+      <button
+        onClick={() => {
+          props.unmergeRecordPersonId("");
+        }}
+        className="govuk-button sv-unmerge-button govuk-!-margin-left-2"
+        data-testid="cancel"
+      >
+        Cancel
+      </button>
+    </div>
   );
 };

--- a/apps/single-view/src/app.scss
+++ b/apps/single-view/src/app.scss
@@ -89,9 +89,16 @@ $lbh-asset-path: "../node_modules/lbh-frontend/dist/assets";
   padding-bottom: inherit;
 }
 
+.sv-buttons-wrapper{
+  display: flex;
+  flex-direction: row;
+  margin-top: 0 !important;
+}
+
 .sv-unmerge-button {
   margin-top: 0 !important;
   margin-bottom: auto !important;
+  border-radius: 4px
 }
 
 .sv-table {

--- a/cypress/integration/2-search.spec.ts
+++ b/cypress/integration/2-search.spec.ts
@@ -63,6 +63,21 @@ describe('search', () => {
     cy.get('.sv-result').eq(1)
         .contains('(NI Number Not Set)');
   });
+  
+  it('displays merge, confirm and cancel buttons for merged records', () => {
+    cy.setCookie('jigsawToken', 'testValue')
+
+    cy.get('#firstName').type('Luna');
+    cy.get('#lastName').type('Kitty');
+
+    cy.intercept('GET', '**/search?**', { fixture: 'person-search.json' }).as('getPersons')
+
+    cy.get('.govuk-button').first().should('have.text', 'Search').click();
+
+    cy.get('[data-testid="unmerge"]').first().click();
+    cy.get('[data-testid="confirm"]').first().should('have.text', "Confirm");
+    cy.get('[data-testid="cancel"]').should('have.text', 'Cancel')
+  });
 
   it('displays merged records with multiple data sources', () => {
     cy.get('#mergedRecords > .lbh-body > .sv-result-sub-wrapper > .sv-result > [data-testid="mergeCounter-0"]') // Gets counter on first result


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/ewCS3RGX/329-unmerge-could-easily-be-mis-clicked-as-it-can-be-confused-with-the-merge-button

## Describe this PR
### What is the problem we're trying to solve
- Both **Merge records** and **unmerge** buttons appear visually similar on search results page, which may lead a user to click **unmerge** in error.
- The merged record gets deleted as soon as **unmerge** button is clicked, that means if it is clicked by error it cannot be reverted. 

### What changes have we introduced
- On clicking **Unmerge**, user gets prompted with two buttons, **Continue** and **Cancel**. When User clicks **Continue** only then the record gets unmerged. If user decides to not to continue and clicks **Cancel** then the merged record does not get deleted.

#### Checklist
- [x] Added tests to cover all new production code

#### Screen recording
https://user-images.githubusercontent.com/31739633/187466881-029b44cf-da81-403e-8cee-a95599241750.mov