### PR TITLE
Shared plan integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,7 @@ jobs:
             export MA_URL=$(aws ssm get-parameter --name /single-view/<<parameters.stage>>/ma-url --query Parameter.Value --output text)
             export JIGSAW_URL=$(aws ssm get-parameter --name /single-view/<<parameters.stage>>/jigsaw-url --query Parameter.Value --output text)
             export RSA_PUBLIC_KEY=$(aws ssm get-parameter --name /single-view/<<parameters.stage>>/rsa_public_key --query Parameter.Value --output text)
+            export SHARED_PLAN_URL=$(aws ssm get-parameter --name /single-view/<<parameters.stage>>/shared_plan_url --query Parameter.Value --output text)
 
             yarn build
       - run:

--- a/apps/single-view/.env.sample
+++ b/apps/single-view/.env.sample
@@ -1,7 +1,8 @@
 APP_ENV=
 APP_CDN=
 SV_API_V1=sv.api
-RSA_PUBLIC_KEY=<rsa public key>
+RSA_PUBLIC_KEY=rsa_public_key
 MMH_URL=https://manage-my-home.dev.gov.uk
 MA_URL=https://managearrears.dev.gov.uk
 JIGSAW_URL=https://live.housingjigsaw.co.uk
+SHARED_PLAN_URL=http://sharedplan.com

--- a/apps/single-view/src/Components/SharedPlans.tsx
+++ b/apps/single-view/src/Components/SharedPlans.tsx
@@ -6,22 +6,20 @@ export function displaySharedPlans(
   person: customerProfile,
   systemIds: Array<SystemId>
 ) {
-  if (person.sharedPlans && person.sharedPlans.length >= 1) {
+  if (person.sharedPlan.planIds && person.sharedPlan.planIds.length >= 1) {
     // Return component linking shared plans
     return (
       <>
-        {person.sharedPlans.map((sharedPlan, index) => {
-          console.log(sharedPlan.id);
+        {person.sharedPlan.planIds.map((planId, index) => {
+          console.log(planId);
           return (
             <p>
               <a
                 className="govuk-link lbh-link lbh-link--no-visited-state"
-                href={
-                  "https://sharedplan.hackney.gov.uk/plans/" + sharedPlan.id
-                }
+                href={process.env.SHARED_PLAN_URL + "/plans/" + planId}
                 target="_blank"
               >
-                View Plan {person.sharedPlans.length > 1 && index}
+                View Plan {person.sharedPlan.planIds.length > 1 && index + 1}
               </a>
             </p>
           );

--- a/apps/single-view/src/Gateways/sharedPlanGateway.tsx
+++ b/apps/single-view/src/Gateways/sharedPlanGateway.tsx
@@ -1,6 +1,5 @@
 import axios from "axios";
 import { customerProfile, SystemId } from "../Interfaces";
-import { getToken } from "../Utils";
 
 const createSharedPlanError = new Error("Error creating shared plan");
 
@@ -10,9 +9,19 @@ export async function createSharedPlan(
 ): Promise<string | Error> {
   const response = await axios.post(
     `${process.env.SV_API_V1}/sharedPlan`,
+    // {
+    //   firstName: "Patrick",
+    //   lastName: "HINDS",
+    //   niNumber: "NY004239B",
+    //   systemIds: ["30389694", "189ff229-925b-49c9-9c8f-58b5f16c8a57"],
+    //   numbers: ["07824826782"],
+    //   emails: ["robert.collins@madetech.com"],
+    //   hasPhp: null,
+    // },
     {
       firstName: person.firstName,
       lastName: person.surname,
+      dateOfBirth: person.dateOfBirth,
       systemIds: systemIds.map((systemId) => systemId.id),
       numbers: person.allContactDetails
         ? person.allContactDetails.filter(
@@ -29,7 +38,7 @@ export async function createSharedPlan(
     {
       headers: {
         "Content-Type": "application/json",
-        Authorization: `${getToken()}`,
+        // Authorization: `${getToken()}`,
       },
     }
   );

--- a/apps/single-view/src/Interfaces/customerProfileInterfaces.tsx
+++ b/apps/single-view/src/Interfaces/customerProfileInterfaces.tsx
@@ -31,7 +31,7 @@ export interface customerProfile {
   councilTaxAccount: councilTaxAccount | null;
   housingBenefitsAccount: housingBenefitsAccount | null;
   equalityInformation: EqualityData | null;
-  sharedPlans: sharedPlan[];
+  sharedPlan: sharedPlan;
 }
 
 export interface supportWorker {
@@ -45,5 +45,5 @@ export interface supportWorker {
 }
 
 export interface sharedPlan {
-  id: string;
+  planIds: Array<string>;
 }

--- a/apps/single-view/src/Views/CustomerView/Profile.tsx
+++ b/apps/single-view/src/Views/CustomerView/Profile.tsx
@@ -1,10 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { DescriptionListItem } from "../../Components";
 import { customerProfile, SystemId, legacyReference } from "../../Interfaces";
-import {
-  formatCautionaryAlertsDate,
-  formatDateOfBirth,
-} from "../../Utils/formatDates";
+import { formatCautionaryAlertsDate, formatDateOfBirth } from "../../Utils";
 import { Center, Spinner } from "@mfe/common/lib/components";
 import { formatDate } from "@mfe/common/lib/utils";
 import { Alert } from "../../Components/Alert";
@@ -106,9 +103,9 @@ export const Profile = (props: Props) => {
 
         <DescriptionListItem
           title={
-            person.sharedPlans && person.sharedPlans.length > 1
-              ? "Shared Plans"
-              : "Shared Plan"
+            person.sharedPlan.planIds && person.sharedPlan.planIds.length <= 1
+              ? "Shared Plan"
+              : "Shared Plans"
           }
           testId="sharedPlans"
         >
@@ -184,7 +181,7 @@ export const Profile = (props: Props) => {
                     </summary>
                     <div className="govuk-details__text sv-details">
                       <ul>
-                        {address.householdMembers?.map((member, i) => {
+                        {address.householdMembers?.map((member, _) => {
                           return (
                             <li>
                               {member.fullName} (

--- a/apps/single-view/webpack.config.js
+++ b/apps/single-view/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = (webpackConfigEnv, argv) => {
         MA_URL: process.env.MA_URL || dotenv.MA_URL,
         JIGSAW_URL: process.env.JIGSAW_URL || dotenv.JIGSAW_URL,
         RSA_PUBLIC_KEY: process.env.RSA_PUBLIC_KEY || dotenv.RSA_PUBLIC_KEY,
+        SHARED_PLAN_URL: process.env.SHARED_PLAN_URL || dotenv.SHARED_PLAN_URL,
       }),
       new ImportMapWebpackPlugin({
         namespace: "@mfe",

--- a/cypress/fixtures/person-profile.json
+++ b/cypress/fixtures/person-profile.json
@@ -10,7 +10,9 @@
         "firstName": "Luna",
         "middleName": "Purry",
         "surname": "Kitty",
-        "sharedPlans": [],
+        "sharedPlan": {
+            "planIds": []
+        },
         "personTypes": [
         "HouseholdMember"
         ],

--- a/cypress/integration/4.1-sharedPlans.spec.ts
+++ b/cypress/integration/4.1-sharedPlans.spec.ts
@@ -7,7 +7,8 @@ describe('Shared Plans', () => {
 			profilePage.visit(AuthRoles.UnrestrictedGroup, JigsawStatuses.Dismissed)
 
 			cy.fixture('person-profile.json').then(personFixture => {
-				personFixture.sharedPlans = [];
+				personFixture.sharedPlan = {};
+				personFixture.sharedPlan.planIds = [];
 				cy.intercept('GET', '**/customers*', personFixture);
 			})
 
@@ -25,7 +26,8 @@ describe('Shared Plans', () => {
 			profilePage.visit(AuthRoles.UnrestrictedGroup, JigsawStatuses.Dismissed)
 
 			cy.fixture('person-profile.json').then(personFixture => {
-				personFixture.sharedPlans = ["plan1", "plan2"];
+				personFixture.sharedPlan = {};
+				personFixture.sharedPlan.planIds = ["plan1", "plan2"];
 				cy.intercept('GET', '**/customers*', personFixture);
 			})
 		})
@@ -38,14 +40,4 @@ describe('Shared Plans', () => {
 
 	});
 
-});
-describe('Plans Found', () => {
-	before(() => {
-		profilePage.visit(AuthRoles.UnrestrictedGroup, JigsawStatuses.Dismissed)
-
-		cy.fixture('person-profile.json').then(personFixture => {
-			personFixture.sharedPlans = ["plan1", "plan2"];
-			cy.intercept('GET', '**/customers*', personFixture);
-		})
-	})
 });


### PR DESCRIPTION
Allows viewing links to existing shared plans for merged records.

Uses the sharedPlan key from the customer response object when opening up a merged record page and displays links for each one.

Sets the URLs for shared plan as environment variables + pulls from AWS.

![image](https://user-images.githubusercontent.com/74552077/189908959-a360b3ad-c0c4-464a-815e-fd6b94f10f03.png)
