### PR TITLE
Only add Google Analytics tag if running in production

### DIFF
--- a/apps/root/src/index.ejs
+++ b/apps/root/src/index.ejs
@@ -23,13 +23,16 @@
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-237577320-1"></script>
         
       <script>
-        window.dataLayer = window.dataLayer || [];
-          function 
+        if (document.location.hostname === "single-view.hackney.gov.uk") {
+            // Only add GA if running in production
+            window.dataLayer = window.dataLayer || [];
+            function
             gtag() {
-            dataLayer.push(arguments);
-          }
-          gtag('js', new Date());
-          gtag('config', 'UA-237577320-1');
+                dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+            gtag('config', 'UA-237577320-1');
+        }
       </script>  
 
   <!--


### PR DESCRIPTION
Checks for single view production URL to add tag