### PR TITLE
Merge pull request #124 from LBHackney-IT/jigsaw-login-redirect-fix

### DIFF
--- a/apps/single-view/src/Components/BackToSearch.tsx
+++ b/apps/single-view/src/Components/BackToSearch.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { getCookie } from "../Utils";
 
 export const BackToSearch = () => {
-  const path = getCookie("searchResidentPath");
+  const path = getCookie("searchResidentPath") || "/search";
   return (
     <>
       <a


### PR DESCRIPTION
Go to /search if cookie not set in back to search

This way the link will work even if the user directly navigates to a person profile page without the cookie set