### PR TITLE
Change Auth Url to Test Instance

### DIFF
--- a/apps/auth/src/services/locale.ts
+++ b/apps/auth/src/services/locale.ts
@@ -4,7 +4,7 @@ const locale = {
   contactToRequestPermission: "To request access please complete this form.",
   signIn: "Sign in",
   signInUsingHackney: "Sign in with Google",
-  authDomain: "https://auth.hackney.gov.uk",
+  authDomain: "https://auth-test.hackney.gov.uk",
 };
 
 // /apps/auth/src/views/login-view/login-view.tsx

--- a/apps/common/lib/config/config.ts
+++ b/apps/common/lib/config/config.ts
@@ -1,7 +1,7 @@
 const config = {
   appEnv: process.env.APP_ENV || "test",
   authAllowedGroups: process.env.AUTH_ALLOWED_GROUPS?.split(",") || ["TEST_GROUP"],
-  authDomain: process.env.AUTH_DOMAIN || "//auth.hackney.gov.uk/auth",
+  authDomain: process.env.AUTH_DOMAIN || "//auth-test.hackney.gov.uk/auth",
   cookieDomain: process.env.COOKIE_DOMAIN || "hackney.gov.uk",
   authToken: process.env.AUTH_TOKEN_NAME || "hackneyToken",
   configurationApiUrlV1: process.env.CONFIGURATION_API_URL_V1 || "",


### PR DESCRIPTION
## What
- This PR changes the url used to authenticate a user and receive a test token

## Why
- This is to test the new insteance of auth running on Node 22, moving away from Node 18 which is unsupported.