### PR TITLE
Revert Use of Test Instance Auth URL

### DIFF
--- a/apps/auth/src/services/locale.ts
+++ b/apps/auth/src/services/locale.ts
@@ -4,7 +4,7 @@ const locale = {
   contactToRequestPermission: "To request access please complete this form.",
   signIn: "Sign in",
   signInUsingHackney: "Sign in with Google",
-  authDomain: "https://auth-test.hackney.gov.uk",
+  authDomain: "https://auth.hackney.gov.uk",
 };
 
 // /apps/auth/src/views/login-view/login-view.tsx

--- a/apps/common/lib/config/config.ts
+++ b/apps/common/lib/config/config.ts
@@ -1,7 +1,7 @@
 const config = {
   appEnv: process.env.APP_ENV || "test",
   authAllowedGroups: process.env.AUTH_ALLOWED_GROUPS?.split(",") || ["TEST_GROUP"],
-  authDomain: process.env.AUTH_DOMAIN || "//auth-test.hackney.gov.uk/auth",
+  authDomain: process.env.AUTH_DOMAIN || "//auth.hackney.gov.uk/auth",
   cookieDomain: process.env.COOKIE_DOMAIN || "hackney.gov.uk",
   authToken: process.env.AUTH_TOKEN_NAME || "hackneyToken",
   configurationApiUrlV1: process.env.CONFIGURATION_API_URL_V1 || "",


### PR DESCRIPTION
## What
The auth url has been reverted to https://auth.hackney.gov.uk

## Why
The url was updated to https://auth-test.hackney.gov.uk to test the new version of the auth instance.  After successfully completing the tests these changes are being reverted.

## Link to JIRA Ticket
[SSI-355](https://hackney.atlassian.net/jira/software/projects/SSI/boards/122?selectedIssue=SSI-355)

[SSI-355]: https://hackney.atlassian.net/browse/SSI-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ